### PR TITLE
URIs prefixed with "#" don't comply the spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,12 +203,28 @@ call
 (secretary/set-config! :prefix "#")
 ```
 
-to prefix generated URIs with a "#". Beware resulting URIs will no longer comply with [standard syntax](https://en.wikipedia.org/wiki/Uniform_Resource_Locator#Syntax) (fragment must be the last part of the URI after the query).
+to prefix generated URIs with a "#".
 
 ```clojure
 (user-path {:id 1})
 ;; => "#/users/1"
 ```
+
+##### This scheme doesn't comply with URI spec
+
+Beware that using prefix that way will make resulting URIs no longer compliant with [standard URI syntax](https://en.wikipedia.org/wiki/Uniform_Resource_Locator#Syntax) – fragment must be the last part of the URI after the query). Indeed, the syntax of an URI is defined as:
+
+    scheme:[//[user:password@]host[:port]][/]path[?query][#fragment]
+
+`secretary` adds a `#` after the path so it makes the fragment hides the query. For instance, the following URL is comprehended two different way by `secretary` and the spec:
+
+```
+https://www.example.com/path/of/app#path/inside/app?query=params&as=defined&by=secretary
+```
+
+- fragment: `"path/inside/app?query=params&as=defined&by=secretary"` for standard libraries but is `"path/inside/app"` according to Secretary
+
+- query: `""` but is `"query=params&as=defined&by=secretary"` according to Secretary
 
 
 ### Available protocols

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ call
 (secretary/set-config! :prefix "#")
 ```
 
-to prefix generated URIs with a "#".
+to prefix generated URIs with a "#". Beware resulting URIs will no longer comply with [standard syntax](https://en.wikipedia.org/wiki/Uniform_Resource_Locator#Syntax) (fragment must be the last part of the URI after the query).
 
 ```clojure
 (user-path {:id 1})


### PR DESCRIPTION
The syntax of an URI is defined as:

    scheme:[//[user:password@]host[:port]][/]path[?query][#fragment]

Prefixing the URI by a `#` makes fragment hides the query. For instance:
```
https://www.example.com/path/of/app#path/inside/app?query=params&as=defined&by=secretary
```
- fragment: `"path/inside/app?query=params&as=defined&by=secretary"` for standard libraries but is `"path/inside/app"` according to Secretary
- query: `""` but is `"query=params&as=defined&by=secretary"` according to Secretary