### PR TITLE
Remove use of merge-with with seq of seqs

### DIFF
--- a/src/secretary/core.cljs
+++ b/src/secretary/core.cljs
@@ -249,7 +249,8 @@
        (when-let [[_ & ms] (re-matches* re route)]
          (->> (interleave params (map decode ms))
               (partition 2)
-              (merge-with vector {})))))))
+              (map (partial apply hash-map))
+              (apply merge-with vector {})))))))
 
 ;;----------------------------------------------------------------------
 ;; Route rendering


### PR DESCRIPTION
This is no longer supported in the latest Clojurescript.

Fixes #100.