### PR TITLE
Generic map-entry ctor and get tests running

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/clojure:lein-2.7.1
+      - image: circleci/clojure:lein-2.8.1-node
       
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images
@@ -31,6 +31,8 @@ jobs:
           # fallback to using the latest cache if no exact match is found
           - v1-dependencies-
 
+      - run: npm install phantomjs-prebuilt
+
       - run: lein deps
 
       - save_cache:
@@ -39,4 +41,5 @@ jobs:
           key: v1-dependencies-{{ checksum "project.clj" }}
         
       # run tests!
-      - run: lein test
+      - run: PATH=~/repo/node_modules/phantomjs-prebuilt/lib/phantom/bin:$PATH lein run-tests | tee test-out.txt
+      - run: grep '0 failures, 0 errors.' test-out.txt

--- a/src/secretary/core.cljs
+++ b/src/secretary/core.cljs
@@ -249,7 +249,7 @@
        (when-let [[_ & ms] (re-matches* re route)]
          (->> (interleave params (map decode ms))
               (partition 2)
-              (map (fn [[k v]] (MapEntry. k v nil)))
+              (map (fn [[k v]] (first {k v})))
               (merge-with vector {})))))))
 
 ;;----------------------------------------------------------------------


### PR DESCRIPTION
The MapEntry deftype was introduced with ClojureScript 1.9.542.
To get the tests running would involve updating the project,
but a simpler change is to not require ClojureScript 1.9.542 by
employing a generic map entry constructor that works on older
ClojureScript versions.