### PR TITLE
Fix failing test on newer versions of Clojure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ pom.xml.asc
 *\#
 .repl/*
 out/*
+/.cljs_node_repl
+/.cpcache

--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,5 @@
+{:deps {}
+ :aliases {:test
+           {:extra-deps {org.clojure/clojurescript {:mvn/version "RELEASE"}
+                         org.clojure/test.check {:mvn/version "RELEASE"}}
+            :extra-paths ["test"]}}}

--- a/test/secretary/test/core.cljs
+++ b/test/secretary/test/core.cljs
@@ -159,8 +159,9 @@
       (is (= (s/dispatch! r)
              {:foo p1 :bar p2})))
 
-    (s/defroute #"/([a-z]+)/search" [letters {:keys [query-params]}]
-      [letters query-params])
+    (s/defroute #"/([a-z]+)/search" {:as params}
+      (let [[letters {:keys [query-params]}] params]
+        [letters query-params]))
 
     (is (= (s/dispatch! "/abc/search")
            ["abc" nil]))


### PR DESCRIPTION
This fixes a test which causes problems (syntax error while macro-expanding) in newer versions of Clojure.